### PR TITLE
feat(plugin): issue warning if trace clock is not monotonic

### DIFF
--- a/src/trace-cmd-private.h
+++ b/src/trace-cmd-private.h
@@ -11,5 +11,6 @@
 struct tracecmd_input;
 
 const char *tracecmd_get_uname(struct tracecmd_input *handle);
+const char *tracecmd_get_trace_clock(struct tracecmd_input *handle);
 
 #endif


### PR DESCRIPTION
We don't know for sure which trace clock is used by LTTng US, but if the trace.dat (ftrace) clock is not monotonic, it is likely that the traces are misaligned. Issue a warning in this case, but proceed.