### PR TITLE
fix(plugin): correctly free trace record on interruption

### DIFF
--- a/src/bt-ftrace-source.c
+++ b/src/bt-ftrace-source.c
@@ -585,8 +585,7 @@ void ftrace_in_message_iterator_finalize(
 	struct ftrace_in_message_iterator *ftrace_in_iter =
 		bt_self_message_iterator_get_data(self_message_iterator);
 
-	/* Close the input file */
-	free(ftrace_in_iter->rec);
+	tracecmd_free_record(ftrace_in_iter->rec);
 
 	/* Redundant, as the packet is always closed when finishing the stream */
 	BT_PACKET_PUT_REF_AND_RESET(ftrace_in_iter->packet);


### PR DESCRIPTION
Trace records need to be freed with tracecdm_free_record instead of free. This was done incorrectly when finalizing the message iterator. However, the bug remained unnoticed as the record is NULL on full iteration, hence the free() is simply a noop.

On partial iteration, the record was not properly freed, leading to a leak and debug output.