### PR TITLE
fix(plugin): limit prio conversion to sched system

### DIFF
--- a/src/bt-ftrace-lttng-events.c
+++ b/src/bt-ftrace-lttng-events.c
@@ -48,12 +48,19 @@ const char *lttng_get_field_name_from_event(const struct tep_event *event,
 	return lttng_field_name_replace_pid_by_tid(field_name);
 }
 
-unsigned long long lttng_get_field_val_from_event(const struct tep_event *event,
-												  const char *field_name,
-												  unsigned long long val)
+uint64_t lttng_get_field_val_from_event_unsigned(const struct tep_event *event,
+												 const char *field_name,
+												 uint64_t val)
+{
+	return val;
+}
+
+int64_t lttng_get_field_val_from_event_signed(const struct tep_event *event,
+											  const char *field_name,
+											  int64_t val)
 {
 	/* LTTng prios are shown as observed by userspace */
-	if (strstr(field_name, "prio")) {
+	if ((strcmp(event->system, "sched") == 0) && strstr(field_name, "prio")) {
 		return val - MAX_RT_PRIO;
 	}
 	return val;

--- a/src/bt-ftrace-lttng-events.h
+++ b/src/bt-ftrace-lttng-events.h
@@ -28,8 +28,12 @@ const char *lttng_get_field_name_from_event(const struct tep_event *event,
  * the prio fields, whereby LTTng's priorities refer to the ones observed from
  * userspace.
  */
-unsigned long long lttng_get_field_val_from_event(const struct tep_event *event,
-												  const char *field_name,
-												  unsigned long long val);
+uint64_t lttng_get_field_val_from_event_unsigned(const struct tep_event *event,
+												 const char *field_name,
+												 uint64_t val);
+
+int64_t lttng_get_field_val_from_event_signed(const struct tep_event *event,
+											  const char *field_name,
+											  int64_t val);
 
 #endif

--- a/src/bt-ftrace-source.c
+++ b/src/bt-ftrace-source.c
@@ -664,24 +664,24 @@ set_message_field_value(struct ftrace_in_message_iterator *ftrace_in_iter,
 						bt_field_class_type data_class_type, void *data,
 						int len)
 {
-	unsigned long long val;
-
 	if (bt_field_class_type_is(data_class_type, BT_FIELD_CLASS_TYPE_STRING)) {
 		bt_field_string_set_value(data_field, data);
 	} else if (bt_field_class_type_is(data_class_type,
 									  BT_FIELD_CLASS_TYPE_SIGNED_INTEGER)) {
-		val = tep_read_number(field->event->tep, data, len);
+		unsigned long long val = tep_read_number(field->event->tep, data, len);
 		int64_t typed_val = convert_to_signed(
 			val, bt_field_class_integer_get_field_value_range(data_class));
 		if (ftrace_in_iter->ftrace_in->lttng_format)
-			val = lttng_get_field_val_from_event(field->event, field_name, val);
+			typed_val = lttng_get_field_val_from_event_signed(
+				field->event, field_name, typed_val);
 		bt_field_integer_signed_set_value(data_field, typed_val);
 	} else if (bt_field_class_type_is(data_class_type,
 									  BT_FIELD_CLASS_TYPE_UNSIGNED_INTEGER)) {
-		val = tep_read_number(field->event->tep, data, len);
+		uint64_t typed_val = tep_read_number(field->event->tep, data, len);
 		if (ftrace_in_iter->ftrace_in->lttng_format)
-			val = lttng_get_field_val_from_event(field->event, field_name, val);
-		bt_field_integer_unsigned_set_value(data_field, (uint64_t)val);
+			typed_val = lttng_get_field_val_from_event_unsigned(
+				field->event, field_name, typed_val);
+		bt_field_integer_unsigned_set_value(data_field, typed_val);
 	}
 }
 


### PR DESCRIPTION
The prios in lttng are different from the ones in ftrace, hence a conversion is needed. However, we must limit this conversion to well-known trace systems (in this case sched only). We further need to ensure, we don't mix signed and unsigned data. Hence we split the converter into two functions.