### PR TITLE
chore(tool):added status checks for bt_graph_run_once

### DIFF
--- a/src/ftrace-to-ctf.c
+++ b/src/ftrace-to-ctf.c
@@ -365,30 +365,23 @@ static int get_metadata_from_lttng_trace(const bt_plugin *ftrace_plugin,
 	{
 		printf("\nError running graph to get trace metadata\n");
 		error_status = -1;
-		return error_status;
 	}
 	if(run_status == BT_GRAPH_RUN_ONCE_STATUS_MEMORY_ERROR)
 	{
 		printf("\nMemory error running graph to get trace metadata\n");
 		error_status = -1;
-		return error_status;
 	}
-	if(run_status == BT_GRAPH_RUN_ONCE_STATUS_END)
-	{
-		printf("\nAll sink components are finished processing.\n");
-	}
-	if(run_status == BT_GRAPH_RUN_ONCE_STATUS_AGAIN)
-	{
-		printf("\nGraph needs to be run again to process all messages.\n");
-	}
-	if(run_status == BT_GRAPH_RUN_ONCE_STATUS_OK)
-	{
-		/* Successfully ran one iteration */
-		printf("\nGraph ran successfully to get trace metadata.\n\n");
-	}
+	
 	BT_GRAPH_PUT_REF_AND_RESET(graph);
 	/* close writer end */
 	close(out_fds[1]);
+	
+	/* exits with error after cleanup */
+	if(error_status != 0)
+	{	
+		close(out_fds[0]);
+		return error_status;
+	}
 
 	FILE *fp = fdopen(out_fds[0], "r");
 	if (!fp) {


### PR DESCRIPTION
Worked on the TODO of the status check for bt_graph_run_once()
get_metadata_from_lttng_trace() now returns -1 on errors

Signed-off-by: Andre Poljakow <andre.poljakow@siemens.com>