### PR TITLE
fix: Cover raw syscall events when prefixing

### DIFF
--- a/src/bt-ftrace-lttng-events.c
+++ b/src/bt-ftrace-lttng-events.c
@@ -74,7 +74,7 @@ const char *lttng_get_event_name_from_event(const struct tep_event *event)
 	} else if (event_system_is("console", event) &&
 			   !event_has_prefix("console_", event)) {
 		return event_prefix_name("console_", event);
-	} else if (event_system_is("syscalls", event)) {
+	} else if (event_system_is("syscalls", event) || event_system_is("raw_syscalls", event)) {
 		return event_syscall_prefix_name(event);
 	}
 	return event->name;


### PR DESCRIPTION
Fixed an issue where sys_enter & sys_exit events were not properly converted  to lttng standards, as they are not under the event system "syscalls", but under "raw_syscalls"