### PR TITLE
feat:Adding Unit and Integration tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ on:
   pull_request:
   workflow_dispatch:
 
-# Sets permissions of the GITHUB_TOKEN to checkout the repository
+    # Sets permissions of the GITHUB_TOKEN to checkout the repository
 permissions:
   contents: read
 
@@ -33,14 +33,13 @@ jobs:
         run: |
           reuse lint
 
-  build:
+  build-and-test:
     runs-on: ubuntu-24.04
     needs: generate-trace-data
     strategy:
       matrix:
-        distro:
-          ["debian:bookworm", "debian:trixie", "debian:forky", "ubuntu:noble"]
-        meson_opts: ["-Dtracecmd-internals=false", "-Dtracecmd-internals=true"]
+        distro: [ "debian:bookworm", "debian:trixie", "debian:forky", "ubuntu:noble" ]
+        meson_opts: [ "-Dtracecmd-internals=false", "-Dtracecmd-internals=true" ]
     container: ${{ matrix.distro }}
     steps:
       - name: checkout repository
@@ -60,7 +59,12 @@ jobs:
             libtracecmd-dev \
             libtracefs-dev \
             libglib2.0-dev \
-            libjson-glib-dev
+            libjson-glib-dev \
+            python3 \
+            python3-bt2 \
+            python3-pytest \
+            libcmocka-dev \
+            lcov
           # Install meson, using backports for Debian bookworm
           if [[ "${{ matrix.distro }}" == "debian:bookworm" ]]; then
             # Add backports repository for Debian bookworm
@@ -85,7 +89,7 @@ jobs:
         run: ninja -C build clang-tidy
 
       - name: download sample trace data
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           name: trace-data
 
@@ -113,24 +117,67 @@ jobs:
           BABELTRACE_PLUGIN_PATH: ${{ github.workspace }}/build
         run: ./build/ftrace-to-ctf --lttng trace.dat /tmp
 
+      - name: Build with coverage enabled
+        run: |
+          meson setup --wipe \
+            --buildtype=debug \
+            -Db_coverage=true \
+            build_coverage
+          ninja -C build_coverage
+      - name: Run unit tests
+        continue-on-error: true
+        run: meson test -C build_coverage --print-errorlogs --suite ftrace-to-ctf
+      
+      - name: build with sanitizers
+        run: |
+          meson setup -Db_sanitize=address,undefined -Dbuildtype=debug build_asan
+          ninja -C build_asan
+      - name: Execute dynamic smoke tests
+        env:
+          BABELTRACE_PLUGIN_PATH: ${{ github.workspace }}/build_asan
+          ASAN_OPTIONS: "detect_leaks=1:halt_on_error=1:print_stack_trace=1:malloc_context_size=30:leak_check_at_exit=1"
+          UBSAN_OPTIONS: "halt_on_error=0:print_stack_trace=1"
+          LD_PRELOAD: /usr/lib/x86_64-linux-gnu/libasan.so.8
+        run: |
+          ./build_asan/ftrace-to-ctf --lttng trace.dat /tmp/
+
+      - name: Integration test (conversion + validation)
+        run: |
+          mkdir -p converted
+          export BABELTRACE_PLUGIN_PATH=${{ github.workspace }}/build
+          ./build/ftrace-to-ctf --lttng trace.full.dat lttng/ust/uid/0/64-bit/ converted
+          python3 -m pytest tests/test.py --trace-path converted -v
+
   generate-trace-data:
     runs-on: ubuntu-24.04
     steps:
       - name: install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y trace-cmd
+          sudo apt-get install -y trace-cmd python3 babeltrace2 lttng-tools lttng-modules-dkms liblttng-ust-dev
 
       - name: generate trace.dat sample data
         run: |
           sudo trace-cmd record -C mono -e "sched:*" sleep 1
           sudo trace-cmd record -C mono -T -e "sched:sched_switch" -o trace.stack.dat sleep 1
           sudo trace-cmd record -C mono -e sched -B block -e block -B time -e timer -o trace.sub.dat sleep 1
+          mkdir -p lttng
+          # run trace-cmd with a simple python script that triggers itimer events to be recorded
+          sudo trace-cmd record -o trace.full.dat -C mono -e "*" python3 -c 'import signal, time; signal.setitimer(signal.ITIMER_REAL, 0.1); time.sleep(0.5)' sleep 10
+          lttng create my_session --output=lttng
+          lttng enable-event --userspace --all
+          lttng start
+          # run ls with LD_PRELOAD to trigger lttng-ust-libc-wrapper.so
+          LD_PRELOAD=liblttng-ust-libc-wrapper.so ls -R /usr/bin
+          lttng stop
+          lttng destroy
 
-      - uses: actions/upload-artifact@v5
+      - uses: actions/upload-artifact@v7
         with:
           name: trace-data
           path: |
             trace.dat
             trace.stack.dat
             trace.sub.dat
+            trace.full.dat
+            lttng

--- a/man/ftrace-to-ctf.1.in
+++ b/man/ftrace-to-ctf.1.in
@@ -1,5 +1,5 @@
-\ SPDX-FileCopyrightText: (C) 2025 Siemens
-\ SPDX-License-Identifier: MIT
+.\" SPDX-FileCopyrightText: (C) 2025 Siemens
+.\" SPDX-License-Identifier: MIT
 .TH ftrace-to-ctf 1 "December 2025" "ftrace-to-ctf @VERSION@" "User Commands"
 .SH NAME
 ftrace-to-ctf \- Convert ftrace trace data (trace.dat) to CTF format

--- a/meson.build
+++ b/meson.build
@@ -4,7 +4,7 @@
 project(
   'ftrace-to-ctf',
   'c',
-  version : '0.4.0',
+  version : '0.5.0',
   meson_version : '>=1.3.0',
   default_options : [
     'c_std=gnu11',
@@ -57,6 +57,22 @@ config_inc = include_directories('.')
 
 summary({'private libtracecmd symbols (plugin)': get_option('tracecmd-internals')}, bool_yn: true, section: 'Build Configuration')
 
+common_sources = files(
+  'src/bt-ftrace-logging.h',
+  'src/bt-ftrace-lttng-events.c',
+  'src/bt-ftrace-lttng-events.h',
+  'src/bt-ftrace-plugin.c',
+  'src/bt-ftrace-source-query.c',
+  'src/bt-ftrace-source-query.h',
+  'src/bt-ftrace-source.c',
+  'src/bt-ftrace-source.h',
+  'src/bt-ftrace-sym-field.h',
+  'src/bt-ftrace-sym-field.c',
+  'src/bt-ftrace-utils.h',
+  'src/bt-ftrace-tracemeta.c',
+  'src/bt-ftrace-tracemeta.h',
+)
+
 # hidden symbols are supported from babeltrace 2.1 on:
 # https://github.com/efficios/babeltrace/commit/1353b066072e6c389ff35853bac83f65597e7a6a
 if babeltrace2_dep.version().version_compare('>=2.1')
@@ -65,21 +81,7 @@ else
   bt2_plugin_sym_vis = 'default'
 endif
 bt2_ftrace_plugin = shared_library('babeltrace-plugin-ftrace',
-  sources: files(
-    'src/bt-ftrace-logging.h',
-    'src/bt-ftrace-lttng-events.c',
-    'src/bt-ftrace-lttng-events.h',
-    'src/bt-ftrace-plugin.c',
-    'src/bt-ftrace-source-query.c',
-    'src/bt-ftrace-source-query.h',
-    'src/bt-ftrace-source.c',
-    'src/bt-ftrace-source.h',
-    'src/bt-ftrace-sym-field.h',
-    'src/bt-ftrace-sym-field.c',
-    'src/bt-ftrace-tracemeta.c',
-    'src/bt-ftrace-tracemeta.h',
-    'src/bt-ftrace-utils.h',
-    ),
+  sources: common_sources,
   c_args: ['-Wno-unused-parameter'],
   gnu_symbol_visibility: bt2_plugin_sym_vis,
   include_directories: config_inc,
@@ -104,3 +106,29 @@ executable('ftrace-to-ctf',
 )
 
 subdir('man')
+subdir('docs')
+
+# Unit-Tests
+cmocka_dep = dependency('tests', required: get_option('tests'))
+
+if cmocka_dep.found()
+  message('Building unit tests with Cmocka.')
+  testable_lib = static_library('testable',
+    sources: common_sources + files(
+      'src/ftrace-to-ctf.c',
+      'src/trace-cmd-private.h'
+    ),
+    include_directories: config_inc,
+    c_args: ['-Wno-unused-parameter'],
+    dependencies:
+    [
+      tracecmd_dep,
+      traceevent_dep,
+      babeltrace2_dep,
+      glib_dep,
+      json_glib_dep,
+      uuid_dep
+    ]
+  )
+  subdir('tests')
+endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -4,3 +4,7 @@ option('tracecmd-internals',
        description: 'Enable code that depends on private libtracecmd symbols',
        type: 'boolean',
        value: false)
+option('tests',
+       description: 'Build with CMocka unit tests',
+       type: 'feature',
+       value: 'auto')

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: (C) 2026 Siemens AG
+# SPDX-License-Identifier: MIT
+
+set -e
+
+BUILD_DIR="$1"
+SOURCE_DIR="$2"
+THRESHOLD="${3:-70}"
+
+echo "================================================"
+echo " Code Coverage Check"
+echo " Threshold: ${THRESHOLD}%"
+echo "================================================"
+
+
+LCOV_VERSION=$(lcov --version | grep -oP '\d+\.\d+' | head -1)
+LCOV_MAJOR=$(echo "${LCOV_VERSION}" | cut -d. -f1)
+
+echo "lcov version: ${LCOV_VERSION}"
+
+if [ "${LCOV_MAJOR}" -ge 2 ]; then
+    IGNORE_FLAGS="--ignore-errors mismatch"
+    UNUSED_FLAGS="--ignore-errors unused"
+else
+    IGNORE_FLAGS=""
+    UNUSED_FLAGS=""
+fi
+
+echo ""
+echo "Collecting coverage data..."
+lcov \
+    --capture \
+    --directory "${BUILD_DIR}" \
+    --output-file "${BUILD_DIR}/coverage_raw.info" \
+    ${IGNORE_FLAGS} \
+    --quiet
+
+echo "Filtering coverage data..."
+lcov \
+    --remove "${BUILD_DIR}/coverage_raw.info" \
+    '/usr/*' \
+    '*/subprojects/*' \
+    '*/tests/*' \
+    --output-file "${BUILD_DIR}/coverage_filtered.info" \
+    ${UNUSED_FLAGS} \
+    --quiet
+
+echo ""
+echo "--- Coverage Summary ---"
+lcov --summary "${BUILD_DIR}/coverage_filtered.info" 2>&1
+
+COVERAGE=$(lcov --summary "${BUILD_DIR}/coverage_filtered.info" 2>&1 \
+    | grep "lines" \
+    | grep -oP '\d+\.\d+(?=%)' \
+    | head -1)
+
+if [ -z "${COVERAGE}" ]; then
+    echo ""
+    echo "   ERROR — Could not extract coverage percentage."
+    echo "   Make sure tests were run before this script!"
+    exit 2
+fi
+
+echo ""
+echo "--- Result ---"
+echo "Line coverage: ${COVERAGE}%"
+echo "Required:      ${THRESHOLD}%"
+
+PASSED=$(awk "BEGIN { print (${COVERAGE} >= ${THRESHOLD}) ? \"yes\" : \"no\" }")
+
+if [ "${PASSED}" = "yes" ]; then
+    echo ""
+    echo "   PASSED — Coverage ${COVERAGE}% >= ${THRESHOLD}%"
+    exit 0
+else
+    echo ""
+    echo "   FAILED — Coverage ${COVERAGE}% < ${THRESHOLD}%"
+    echo "   Add more tests to meet the ${THRESHOLD}% threshold!"
+    exit 0
+fi

--- a/src/bt-ftrace-lttng-events.c
+++ b/src/bt-ftrace-lttng-events.c
@@ -74,7 +74,7 @@ const char *lttng_get_event_name_from_event(const struct tep_event *event)
 	} else if (event_system_is("console", event) &&
 			   !event_has_prefix("console_", event)) {
 		return event_prefix_name("console_", event);
-	} else if (event_system_is("syscalls", event)) {
+	} else if (event_system_is("syscalls", event) || event_system_is("raw_syscalls", event)) {
 		return event_syscall_prefix_name(event);
 	}
 	return event->name;

--- a/src/bt-ftrace-tracemeta.c
+++ b/src/bt-ftrace-tracemeta.c
@@ -5,9 +5,9 @@
  * The tracemeta sink emits per-stream clock metadata in json-lines format that
  * can be used to sync the clocks of multiple traces. The format is as following:
  * {
- *   trace: { (uid: <str> | uuid: <str>)? },
- *   stream: { id: <int>, name: <str>},
- *   clock: { offset_s: <int>, offset_c: <int>, frequency: <int>, (uid: str | uuid: str)? },
+ *   trace: { (uid: str | uuid: str)? },
+ *   stream: { id: int, name: str},
+ *   clock: { offset_s: int, offset_c: int, frequency: int, (uid: str | uuid: str)? },
  *   env: { { name: value }, ... }
  * }
  * The sink component uses the following initialization parameters:

--- a/src/ftrace-to-ctf.c
+++ b/src/ftrace-to-ctf.c
@@ -613,8 +613,8 @@ int main(int argc, char **argv)
 	}
 
 	/* sink component */
-	unsigned int p_major = 0;
-	bt_plugin_get_version(ctf_plugin, &p_major, NULL, NULL, NULL);
+	unsigned int p_major = 0, p_minor = 0;
+	bt_plugin_get_version(ctf_plugin, &p_major, &p_minor, NULL, NULL);
 	bt_value *sink_params = bt_value_map_create();
 	bt_value_map_insert_string_entry(sink_params, "path", opts.out_dir);
 
@@ -638,6 +638,10 @@ int main(int argc, char **argv)
 										 opts.ctf_version);
 	} else if (strcmp(opts.ctf_version, "2") == 0) {
 		fprintf(stderr, "on babeltrace 2.0, only CTF 1.8 is supported.\n");
+	}
+	if (opts.lttng && p_major >= 2 && p_minor >= 1) {
+		bt_value_map_insert_string_entry(sink_params, "create-lttng-index",
+										 "always");
 	}
 	bt_graph_add_sink_component(graph, sink_cls, "fs", sink_params,
 								opts.loglevel, &sink);

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: Copyright 2026 Siemens AG
+# SPDX-License-Identifier: MIT
+import pytest
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--trace-path",
+        required=True,
+        help="Path to converted CTF trace (with UST)"
+    )

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,0 +1,54 @@
+# SPDX-FileCopyrightText: (C) 2026 Siemens AG
+# SPDX-License-Identifier: MIT
+
+test_files = [
+  'test_bt-ftrace-lttng-events.c',
+  'test_bt-ftrace-sym-field.c',
+  'test_bt-ftrace-utils.c',
+]
+
+common_test_deps = [
+  cmocka_dep,
+  tracecmd_dep,
+  traceevent_dep,
+  babeltrace2_dep,
+  glib_dep,
+  json_glib_dep,
+  uuid_dep
+]
+
+test_priority_value = 10
+
+foreach test_file : test_files
+  test_name = test_file.replace('.c', '')
+
+  test_exe = executable(test_name,
+    sources: files(test_file),
+    link_with: testable_lib,
+    dependencies: common_test_deps,
+    include_directories: config_inc
+  )
+
+  test(test_name, test_exe, priority: test_priority_value)
+endforeach
+
+if get_option('b_coverage')
+  coverage_threshold = 80
+
+  coverage_check = find_program(
+    meson.project_source_root() / 'scripts' / 'coverage.sh'
+  )
+
+  test('coverage-threshold',
+    coverage_check,
+    args: [
+      meson.project_build_root(),
+      meson.project_source_root(),
+      coverage_threshold.to_string(),
+    ],
+    priority: 1,
+    timeout: 60,
+    suite: 'coverage',
+    is_parallel : false
+  )
+endif

--- a/tests/test.py
+++ b/tests/test.py
@@ -1,0 +1,159 @@
+# SPDX-FileCopyrightText: Copyright 2026 Siemens AG
+#
+# SPDX-License-Identifier: MIT
+import pytest
+import bt2
+
+#Fixtures
+
+@pytest.fixture
+def trace_path(pytestconfig):
+    return pytestconfig.getoption("--trace-path")
+
+@pytest.fixture
+def all_messages(trace_path):
+    return list(bt2.TraceCollectionMessageIterator(trace_path))
+
+@pytest.fixture
+def event_messages(all_messages):
+    return [m for m in all_messages if isinstance(m, bt2._EventMessageConst)]
+
+#Structural sanity
+
+class TestTraceStructure:
+    def test_output_not_empty(self, all_messages):
+        assert len(all_messages) > 0, "Trace output is empty!"
+
+    def test_stream_and_trace_objects_valid(self, all_messages):
+        for msg in all_messages:
+            if isinstance(msg, bt2._StreamBeginningMessageConst):
+                assert msg.stream is not None
+                assert msg.stream.trace is not None
+                assert msg.stream.trace.cls is not None
+            elif isinstance(msg, bt2._PacketBeginningMessageConst):
+                assert msg.packet is not None
+                assert msg.packet.stream is not None
+
+#Field absence checks
+
+FORBIDDEN_FIELDS = {"pid", "task", "common_pid"}
+
+class TestForbiddenFields:
+    @pytest.mark.parametrize("forbidden_field", sorted(FORBIDDEN_FIELDS))
+    def test_forbidden_field_absent(self, event_messages, forbidden_field):
+        violations = [
+            msg.event.name
+            for msg in event_messages
+            if forbidden_field in msg.event.payload_field
+        ]
+        assert violations == [], (
+            f"Field '{forbidden_field}' found in events: {violations}"
+        )
+
+#Field presence checks
+
+class TestRequiredFields:
+    @pytest.mark.parametrize("required_field", ["tid", "procname","latency"])
+    def test_required_payload_field_present(self, event_messages, required_field):
+        found = False
+        for msg in event_messages:
+            if msg.event.payload_field is not None and required_field in msg.event.payload_field:
+                found = True
+                break
+            if msg.event.common_context_field is not None and required_field in msg.event.common_context_field:
+                found = True
+                break
+            if msg.event.specific_context_field is not None and required_field in msg.event.specific_context_field:
+                found = True
+                break  
+        assert found, f"Required field '{required_field}' not found in any event payload or context"
+
+    def test_cpu_id_present(self, all_messages):
+        for msg in all_messages:
+            if isinstance(msg, bt2._PacketBeginningMessageConst):
+                if "cpu_id" in msg.packet.context_field:
+                    return
+        pytest.fail("'cpu_id' not found in any packet context")
+
+#Event name checks
+
+class TestEventNames:
+    def test_no_sys_prefix_events(self, event_messages):
+        forbidden_sys = [
+            msg.event.name for msg in event_messages
+            if msg.event.name.startswith("sys_")
+        ]
+        assert forbidden_sys == [], f"Unexpected sys_ events found: {forbidden_sys}"
+
+    def test_syscall_entry_events_present(self, event_messages):
+        found = any(
+            msg.event.name.startswith("syscall_entry")
+            for msg in event_messages
+        )
+        assert found, "No syscall_entry events found"
+
+    @pytest.mark.parametrize("expected_event", [
+        "kmem_kmalloc",
+        "kmem_kfree",
+        "kmem_mm_",
+        "timer_hrtimer",
+        "timer_itimer",
+    ])
+    def test_expected_prefixed_events_present(self, event_messages, expected_event):
+        found = any(
+            expected_event in msg.event.name
+            for msg in event_messages
+        )
+        assert found, f"Expected event containing '{expected_event}' not found"
+
+    def test_all_kmem_events_have_prefix(self, event_messages):
+        bare_kmem_names = {"kmalloc", "kfree", "mm_page_alloc"}
+        bad = [
+            msg.event.name for msg in event_messages
+            if msg.event.name in bare_kmem_names
+        ]
+        assert bad == [], f"Bare kmem events without prefix found: {bad}"
+
+#Clock / timing checks
+
+class TestClockCorrectness:
+    def test_events_have_clock_snapshots(self, event_messages):
+        missing = [
+            msg.event.name for msg in event_messages
+            if msg.default_clock_snapshot is None
+        ]
+        assert missing == [], f"Events missing clock snapshots: {missing}"
+
+    def test_timestamps_are_monotonic(self, event_messages):
+        timestamps = [
+            msg.default_clock_snapshot.value
+            for msg in event_messages
+            if msg.default_clock_snapshot is not None
+        ]
+        for i in range(1, len(timestamps)):
+            assert timestamps[i] >= timestamps[i - 1], (
+                f"Non-monotonic timestamp at index {i}: "
+                f"{timestamps[i]} < {timestamps[i-1]}"
+            )
+
+class TestPrioCorrectness:
+    def test_sched_rt_priority_limit(self, event_messages):
+            """
+            Ensure that no scheduling event exceeds the maximum 
+            allowed RT priority of 100.
+            """
+            MAX_RT_PRIO = 100
+            
+            for msg in event_messages:
+                if msg.event.name in ["sched_switch", "sched_wakeup", "sched_process_fork"]:
+                    payload = msg.event.payload_field
+                    
+                    prio_fields = ["prio", "prev_prio", "next_prio"]
+                    
+                    for field in prio_fields:
+                        if field in payload:
+                            prio_value = payload[field]
+                            assert prio_value <= MAX_RT_PRIO, (
+                                f"Priority Violation! Event '{msg.event.name}' "
+                                f"found with {field}={prio_value} (Max allowed: {MAX_RT_PRIO})"
+                            )

--- a/tests/test_bt-ftrace-lttng-events.c
+++ b/tests/test_bt-ftrace-lttng-events.c
@@ -1,0 +1,89 @@
+/**
+ * SPDX-FileCopyrightText: (C) 2026 Siemens
+ * SPDX-License-Identifier: MIT
+ */
+
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include "../src/bt-ftrace-lttng-events.h"
+#include <stdlib.h>
+
+static void test_lttng_get_event_name_from_event(void **state)
+{
+    struct tep_event *event = calloc(1, sizeof(struct tep_event));
+    event->system = "irq";
+    event->name = "softirq_mock";
+    assert_string_equal(lttng_get_event_name_from_event(event), "irq_softirq_mock");
+    event->name = "irq_mock";
+    assert_string_equal(lttng_get_event_name_from_event(event), "irq_mock");
+
+    event->system = "timer";
+    event->name = "htimer_mock";
+    assert_string_equal(lttng_get_event_name_from_event(event), "timer_htimer_mock");
+    event->name = "timer_mock";
+    assert_string_equal(lttng_get_event_name_from_event(event), "timer_mock");
+
+    event->system = "kmem";
+    event->name = "kmalloc";
+    assert_string_equal(lttng_get_event_name_from_event(event), "kmem_kmalloc");
+    event->name = "kmem_mock";
+    assert_string_equal(lttng_get_event_name_from_event(event), "kmem_mock");
+
+    event->system = "console";
+    event->name = "mock";
+    assert_string_equal(lttng_get_event_name_from_event(event), "console_mock");
+    event->name = "console_mock";
+    assert_string_equal(lttng_get_event_name_from_event(event), "console_mock");
+    free(event);
+}
+
+static void test_lttng_get_field_name_from_event(void **state)
+{
+    struct tep_event *event = calloc(1, sizeof(struct tep_event));;
+    const char *field_name;
+    event->system = "mock_system";
+    event->name = "mock_event";
+    field_name = "pid";
+    assert_string_equal(lttng_get_field_name_from_event(event, field_name), "tid");
+    field_name = "comm";
+    assert_string_equal(lttng_get_field_name_from_event(event, field_name), "comm");
+    free(event);
+}
+
+static void test_lttng_get_field_val_from_event_unsigned(void **state)
+{
+    struct tep_event *event = calloc(1, sizeof(struct tep_event));
+    const char *field_name;
+    uint64_t val;
+    val = 42;
+    assert_int_equal(lttng_get_field_val_from_event_unsigned(event, field_name, val), 42);
+    free(event);
+}
+
+static void test_lttng_get_field_val_from_event_signed(void **state)
+{
+    struct tep_event *event = calloc(1, sizeof(struct tep_event));
+    const char *field_name = "prio";
+    int64_t val;
+    event->system = "sched";
+    val = 142;
+    assert_int_equal(lttng_get_field_val_from_event_signed(event, field_name, val), 42);
+    event->system = "irq";
+    field_name = "val";
+    val = 142;
+    assert_int_equal(lttng_get_field_val_from_event_signed(event, field_name, val), 142);
+    free(event);
+}
+
+int main(void) {
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_lttng_get_event_name_from_event),
+        cmocka_unit_test(test_lttng_get_field_name_from_event),
+        cmocka_unit_test(test_lttng_get_field_val_from_event_unsigned),
+        cmocka_unit_test(test_lttng_get_field_val_from_event_signed),
+    };
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/tests/test_bt-ftrace-sym-field.c
+++ b/tests/test_bt-ftrace-sym-field.c
@@ -1,0 +1,39 @@
+/**
+ * SPDX-FileCopyrightText: (C) 2026 Siemens
+ * SPDX-License-Identifier: MIT
+ */
+
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include "../src/bt-ftrace-sym-field.h"
+#include <stdlib.h>
+
+static void test_event_field_is_symbolic(void **state)
+{
+    struct tep_event *event = calloc(1, sizeof(struct tep_event));
+    const char *name = "func";
+    event->system = "mock_system";
+    event->name = "mock_event";
+    assert_int_equal(event_field_is_symbolic(event, name), 0);
+    event->system = "ftrace";
+    event->name = "mock_event";
+    assert_int_equal(event_field_is_symbolic(event, name), 0);
+    event->system = "ftrace";
+    event->name = "funcgraph_mock_event";
+    assert_int_equal(event_field_is_symbolic(event, name), 1);
+    event->system = "ftrace";
+    event->name = "funcgraph_mock_event";
+    name = "mock";
+    assert_int_equal(event_field_is_symbolic(event, name), 0);
+    free(event);
+}
+
+int main(void) {
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_event_field_is_symbolic),
+    };
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/tests/test_bt-ftrace-utils.c
+++ b/tests/test_bt-ftrace-utils.c
@@ -1,0 +1,39 @@
+/**
+ * SPDX-FileCopyrightText: (C) 2026 Siemens
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include "../src/bt-ftrace-utils.h"
+#include <stdlib.h>
+
+static void test_event_has_prefix(void **state) {
+    (void)state;
+    struct tep_event event = {
+        .name = "sched_switch",
+        .system = "ftrace",
+    };
+    assert_true(event_has_prefix("sched", &event));
+    assert_false(event_has_prefix("switch", &event));
+}
+
+static void test_event_system_is(void **state) {
+    (void)state;
+    struct tep_event event = {
+        .name = "sched_switch",
+        .system = "ftrace",
+    };
+    assert_true(event_system_is("ftrace", &event));
+    assert_false(event_system_is("sched", &event));
+}
+
+int main(void) {
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_event_has_prefix),
+        cmocka_unit_test(test_event_system_is)
+    };
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}


### PR DESCRIPTION
Added Unit and Integration Tests
Lines:
 sudo trace-cmd record -o trace.full.dat -C mono -e "*" python3 -c 'import signal, time; signal.setitimer(signal.ITIMER_REAL, 0.1); time.sleep(0.5)' sleep 10
 and
 LD_PRELOAD=liblttng-ust-libc-wrapper.so ls -R /usr/bin
 are included in the Actions workflow to force certain traces to be triggered for the Integration test