### PR TITLE
Add progress reporting infrastructure for ftrace source

### DIFF
--- a/man/ftrace-to-ctf.1.in
+++ b/man/ftrace-to-ctf.1.in
@@ -32,6 +32,12 @@ Name of the trace (session).  Stored in the CTF metadata as \fBtrace_name\fR.
 \fB-o, --clock-offset \fIoffset\fR
 Trace clock offset in nanoseconds relative to the world clock.  If omitted, the program attempts to read the offset from a provided LTTng trace.
 .TP
+\fB-P, --progress-path \fIpath\fR
+Write psplash-style progress commands to a FIFO at \fIpath\fR.  Progress is reported based on the timestamp range of the trace data.
+.TP
+\fB-p, --progress-fd \fIfd\fR
+Write psplash-style progress commands to the given file descriptor \fIfd\fR.
+.TP
 \fB-u, --clock-uid \fI(uid|uuid)\fR
 Clock UID (or UUID, depending on the MIP version).  Stored in the CTF metadata as \fBclock-uid\fR.
 .TP

--- a/src/bt-ftrace-source-query.c
+++ b/src/bt-ftrace-source-query.c
@@ -59,6 +59,49 @@ static int get_last_record_ts_clbk(struct tracecmd_input *tc_input,
 }
 #endif
 
+static uint64_t get_last_cpu_ts(struct tracecmd_input *tc_input, int cpu)
+{
+	uint64_t ts = 0;
+	struct tep_handle *tep = tracecmd_get_tep(tc_input);
+	const int ncpus = tep_get_cpus(tep);
+	cpu_set_t cpu_set;
+
+	CPU_ZERO(&cpu_set);
+	CPU_SET(cpu, &cpu_set);
+
+#if HAS_TRACECMD_REVERSE_ITERATION
+	/*
+	 * O(1) implementation, potentially with upstream memory leak as reported in
+	 * https://lore.kernel.org/linux-trace-devel/20251121134749.1530855-1-felix.moessbauer@siemens.com/
+	 */
+	tracecmd_iterate_events_reverse(tc_input, &cpu_set, ncpus,
+									get_last_record_ts_clbk, (void *)&ts, 0);
+#else
+	/* O(n) implementation iterating the whole trace file */
+	struct tep_record *rec = tracecmd_read_cpu_first(tc_input, cpu);
+	while (rec) {
+		ts = rec->ts;
+		tracecmd_free_record(rec);
+		rec = tracecmd_read_data(tc_input, cpu);
+	}
+#endif
+	return ts;
+}
+
+uint64_t get_buffer_end_ts(struct tracecmd_input *tc_input)
+{
+	uint64_t ts_max = 0;
+	struct tep_handle *tep = tracecmd_get_tep(tc_input);
+	const int ncpus = tep_get_cpus(tep);
+
+	for (int i = 0; i < ncpus; ++i) {
+		uint64_t ts = get_last_cpu_ts(tc_input, i);
+		if (ts > ts_max)
+			ts_max = ts;
+	}
+	return ts_max;
+}
+
 static void append_stream_infos(struct tracecmd_input *tc_input,
 								const char *buffer_name, bt_value *infos)
 {
@@ -86,28 +129,8 @@ static void append_stream_infos(struct tracecmd_input *tc_input,
 		bt_value_map_insert_empty_map_entry(streaminfo, "range-ns", &range);
 		bt_value_map_insert_signed_integer_entry(range, "begin-ns",
 												 (int64_t)ts_begin);
-		cpu_set_t cpu_set;
-		CPU_ZERO(&cpu_set);
-		CPU_SET(i, &cpu_set);
-		uint64_t ts_end = ts_begin;
-#if HAS_TRACECMD_REVERSE_ITERATION
-		/* 
-		 * O(1) implementation, potentially with upstream memory leak as reported in
-		 * https://lore.kernel.org/linux-trace-devel/20251121134749.1530855-1-felix.moessbauer@siemens.com/
-		 */
-		tracecmd_iterate_events_reverse(tc_input, &cpu_set, ncpus,
-										get_last_record_ts_clbk,
-										(void *)&ts_end, 0);
-#else
-		/* O(n) implementation iterating the whole trace file */
-		rec = tracecmd_read_cpu_first(tc_input, i);
-		while (rec) {
-			ts_end = rec->ts;
-			tracecmd_free_record(rec);
-			rec = tracecmd_read_data(tc_input, i);
-		}
-#endif
-		bt_value_map_insert_signed_integer_entry(range, "end-ns", ts_end);
+		bt_value_map_insert_signed_integer_entry(
+			range, "end-ns", (int64_t)get_last_cpu_ts(tc_input, i));
 	}
 }
 

--- a/src/bt-ftrace-source-query.h
+++ b/src/bt-ftrace-source-query.h
@@ -7,11 +7,16 @@
 #define _BT_FTRACE_SOURCE_QUERY_H
 
 #include <babeltrace2/babeltrace.h>
+#include <stdint.h>
+
+struct tracecmd_input;
 
 bt_component_class_query_method_status
 ftrace_query_method(bt_self_component_class_source *self_component_class,
 					bt_private_query_executor *query_executor,
 					const char *object_name, const bt_value *params,
 					void *method_data, const bt_value **result);
+
+uint64_t get_buffer_end_ts(struct tracecmd_input *tc_input);
 
 #endif

--- a/src/bt-ftrace-source.c
+++ b/src/bt-ftrace-source.c
@@ -38,6 +38,7 @@
 #include "bt-ftrace-lttng-events.h"
 #include "bt-ftrace-logging.h"
 #include "bt-ftrace-source.h"
+#include "bt-ftrace-source-query.h"
 #include "bt-ftrace-sym-field.h"
 #include "bt-ftrace-utils.h"
 #if WITH_TRACE_CMD_PRIVATE_SYMBOLS
@@ -45,11 +46,12 @@
 #endif
 
 #include <babeltrace2/babeltrace.h>
-#include <event-parse.h>
+#include <errno.h>
+#include <fcntl.h>
 #include <glib.h>
 #include <inttypes.h>
 #include <libgen.h>
-#include <stdint.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <trace-cmd.h>
@@ -118,6 +120,13 @@ struct ftrace_in {
 
 	/* mip version of the processing graph */
 	uint64_t mip_version;
+
+	/* progress reporting */
+	int progress_fd;
+	char *progress_path;
+	uint64_t progress_begin_ts;
+	uint64_t progress_end_ts;
+	uint64_t progress_last_emitted;
 };
 
 /*
@@ -141,6 +150,35 @@ static void parse_tracedat_opts(struct ftrace_in *ftrace_in)
 #else
 	ftrace_in->trace_sysname = strdup("Linux");
 #endif
+}
+
+static void emit_progress(struct ftrace_in *ftrace_in, const char *status)
+{
+	if (ftrace_in->progress_fd < 0)
+		return;
+
+	if (ftrace_in->progress_end_ts <= ftrace_in->progress_begin_ts)
+		return;
+
+	int pct =
+		(int)((ftrace_in->progress_last_emitted -
+			   ftrace_in->progress_begin_ts) *
+			  100 /
+			  (ftrace_in->progress_end_ts - ftrace_in->progress_begin_ts));
+	if (pct > 100)
+		pct = 100;
+
+	char buf[256];
+	int n = snprintf(buf, sizeof(buf), "PROGRESS %d\nSTATUS %s\n", pct,
+					 status ? status : "");
+	if (n > 0) {
+		if (write(ftrace_in->progress_fd, buf, n) < 0 && errno != EAGAIN &&
+			errno != EINTR) {
+			BT_FTRACE_LOG_WARNING(ftrace_in->log_level,
+								  "failed to write progress: %s",
+								  strerror(errno));
+		}
+	}
 }
 
 static bt_field_class *

--- a/src/bt-ftrace-source.c
+++ b/src/bt-ftrace-source.c
@@ -660,6 +660,9 @@ static void ftrace_in_free(struct ftrace_in *ftrace_in)
 	free(ftrace_in->trace_sysname);
 	free(ftrace_in->trace_kernel_release);
 	free(ftrace_in->trace_creation_datetime);
+	if (ftrace_in->progress_fd >= 0)
+		close(ftrace_in->progress_fd);
+	free(ftrace_in->progress_path);
 	free(ftrace_in);
 }
 
@@ -735,6 +738,26 @@ ftrace_in_initialize(bt_self_component_source *self_component_source,
 		ftrace_in->with_callstacks = bt_value_bool_get(callstack_val);
 	}
 
+	ftrace_in->progress_fd = -1;
+	ftrace_in->progress_path = NULL;
+	ftrace_in->progress_begin_ts = 0;
+	ftrace_in->progress_end_ts = 0;
+	ftrace_in->progress_last_emitted = 0;
+	const bt_value *progress_fd_val =
+		bt_value_map_borrow_entry_value_const(params, "progress-fd");
+	if (progress_fd_val) {
+		ftrace_in->progress_fd =
+			(int)bt_value_integer_signed_get(progress_fd_val);
+	}
+	const bt_value *progress_path_val =
+		bt_value_map_borrow_entry_value_const(params, "progress-path");
+	if (progress_path_val) {
+		ftrace_in->progress_path =
+			strdup(bt_value_string_get(progress_path_val));
+		ftrace_in->progress_fd =
+			open(ftrace_in->progress_path, O_WRONLY | O_NONBLOCK);
+	}
+
 	struct tracecmd_input *tc_main =
 		tracecmd_open(path, TRACECMD_FL_LOAD_NO_PLUGINS);
 	if (!tc_main) {
@@ -770,6 +793,13 @@ ftrace_in_initialize(bt_self_component_source *self_component_source,
 	if (ret) {
 		/* TODO: cleanup */
 		return BT_COMPONENT_CLASS_INITIALIZE_METHOD_STATUS_ERROR;
+	}
+
+	if (ftrace_in->progress_fd >= 0) {
+		ftrace_in->progress_begin_ts =
+			tracecmd_get_first_ts(ftrace_in->tc_buffers[0].tc_input);
+		ftrace_in->progress_end_ts =
+			get_buffer_end_ts(ftrace_in->tc_buffers[0].tc_input);
 	}
 
 	return BT_COMPONENT_CLASS_INITIALIZE_METHOD_STATUS_OK;
@@ -1267,6 +1297,7 @@ next_record:
 	 * and in discarded event messages.
 	 */
 	ftrace_in_iter->last_rec_ts = rec->ts;
+	ftrace_in_iter->ftrace_in->progress_last_emitted = rec->ts;
 
 	/* read next record */
 	tracecmd_free_record(rec);
@@ -1309,6 +1340,7 @@ ftrace_in_message_iterator_next(bt_self_message_iterator *self_message_iterator,
 			status = BT_MESSAGE_ITERATOR_CLASS_NEXT_METHOD_STATUS_END;
 			break;
 		}
+		emit_progress(ftrace_in_iter->ftrace_in, "converting");
 	} while (i < capacity);
 
 	if (i > 0) {
@@ -1340,6 +1372,7 @@ ftrace_in_message_iterator_seek_beginning(
 	ftrace_in_iter->events_discarded = 0;
 	ftrace_in_iter->last_rec_ts = 0;
 	ftrace_in_iter->state = FTRACE_IN_MESSAGE_ITERATOR_STATE_STREAM_BEGINNING;
+	ftrace_in_iter->ftrace_in->progress_last_emitted = 0;
 
 	return BT_MESSAGE_ITERATOR_CLASS_SEEK_BEGINNING_METHOD_STATUS_OK;
 }

--- a/src/ftrace-to-ctf.c
+++ b/src/ftrace-to-ctf.c
@@ -15,6 +15,7 @@
 #include <stdbool.h>
 #include <stdlib.h>
 #include <uuid.h>
+#include <poll.h>
 
 /* Structure that holds the parsed options */
 typedef struct {
@@ -35,6 +36,9 @@ typedef struct {
 	int loglevel;
 	int progress_fd;
 	char *progress_path;
+	/* Interactive progress bar: internal pipe fds */
+	int progress_pipe[2];
+	bool use_progress_bar;
 } prog_opts;
 
 typedef struct {
@@ -123,13 +127,13 @@ int parse_args(int argc, char *argv[], prog_opts *opts)
 		{ "symbolize",   no_argument,       0, 's' },
 		{ "end",         required_argument, 0, 'e' },
 		{ "lttng",       no_argument,       0, 'l' },
+		{ "progress-fd",   required_argument, 0, 'p' },
+		{ "progress-path", required_argument, 0, 'P' },
 		{ "trace-dt",    required_argument, 0, 'd' },
 		{ "trace-name",  required_argument, 0, 'n' },
 		{ "verbose",     no_argument,       0, 'v' },
-		{ "help",           no_argument,       0, 'h' },
-		{ "progress-fd",    required_argument, 0, 'p' },
-		{ "progress-path",  required_argument, 0, 'P' },
-		{ 0,                0,                 0,  0  }
+		{ "help",        no_argument,       0, 'h' },
+		{ 0,             0,                 0,  0  }
 	};
 	// clang-format on
 
@@ -461,6 +465,76 @@ static int get_metadata_from_lttng_trace(const bt_plugin *ftrace_plugin,
 	return status;
 }
 
+/*
+ * Parse a progress message from the pipe and return the percentage.
+ * Returns -1 if no valid progress message was found.
+ */
+static int parse_progress_msg(const char *buf)
+{
+	const char *pct_str = strstr(buf, "PROGRESS ");
+	if (!pct_str)
+		return -1;
+
+	pct_str += 9;
+	char *endptr;
+	int pct = strtol(pct_str, &endptr, 10);
+	if (pct_str == endptr)
+		return -1;
+
+	if (pct < 0)
+		pct = 0;
+	if (pct > 100)
+		pct = 100;
+
+	return pct;
+}
+
+/*
+ * Render an interactive progress bar on stderr.
+ * Uses \r to overwrite the current line.
+ */
+static void render_progress_bar(int pct)
+{
+	const int bar_width = 40;
+	int filled = (pct * bar_width) / 100;
+
+	fprintf(stderr, "\r[");
+	for (int i = 0; i < bar_width; i++) {
+		if (i < filled)
+			fputc('#', stderr);
+		else
+			fputc(' ', stderr);
+	}
+	fprintf(stderr, "] %3d%%", pct);
+	fflush(stderr);
+}
+
+/*
+ * Drain any pending progress messages from the pipe and update the bar.
+ * Uses poll() for non-blocking read.
+ */
+static void update_progress_bar(int pipe_fd)
+{
+	char buf[512];
+	ssize_t nr;
+	int pct = -1;
+
+	struct pollfd pfd = { .fd = pipe_fd, .events = POLLIN };
+	while (poll(&pfd, 1, 0) > 0 && (pfd.revents & POLLIN)) {
+		nr = read(pipe_fd, buf, sizeof(buf) - 1);
+		if (nr <= 0)
+			break;
+
+		buf[nr] = '\0';
+		int new_pct = parse_progress_msg(buf);
+		if (new_pct >= 0)
+			pct = new_pct;
+	}
+
+	if (pct >= 0)
+		render_progress_bar(pct);
+}
+
 int main(int argc, char **argv)
 {
 	const bt_component_source *source = NULL;
@@ -571,6 +645,17 @@ int main(int argc, char **argv)
 		BT_PLUGIN_PUT_REF_AND_RESET(ctf_plugin);
 		clear_opts(&opts);
 		return error_status;
+	}
+
+	/* Set up interactive progress bar when running from a tty */
+	opts.use_progress_bar = false;
+	opts.progress_pipe[0] = -1;
+	opts.progress_pipe[1] = -1;
+	if (isatty(STDERR_FILENO) && opts.progress_fd < 0 && !opts.progress_path) {
+		if (pipe(opts.progress_pipe) == 0) {
+			opts.progress_fd = opts.progress_pipe[1];
+			opts.use_progress_bar = true;
+		}
 	}
 
 	bt_graph *graph = bt_graph_create(opts.mip);
@@ -714,6 +799,9 @@ int main(int argc, char **argv)
 	bt_bool is_running = 1;
 	while (is_running) {
 		status = bt_graph_run_once(graph);
+		if (opts.use_progress_bar)
+			update_progress_bar(opts.progress_pipe[0]);
+
 		switch (status) {
 		case BT_GRAPH_RUN_ONCE_STATUS_OK:
 			break;
@@ -731,6 +819,11 @@ int main(int argc, char **argv)
 			printf("other error\n");
 			break;
 		}
+	}
+	if (opts.use_progress_bar) {
+		render_progress_bar(100);
+		fprintf(stderr, "\n");
+		close(opts.progress_pipe[0]);
 	}
 	if (status != BT_GRAPH_RUN_ONCE_STATUS_END) {
 		printf("graph execution failed\n");

--- a/src/ftrace-to-ctf.c
+++ b/src/ftrace-to-ctf.c
@@ -33,6 +33,8 @@ typedef struct {
 	char *lttng_path;
 	char *out_dir;
 	int loglevel;
+	int progress_fd;
+	char *progress_path;
 } prog_opts;
 
 typedef struct {
@@ -48,21 +50,23 @@ static void print_usage(char *prog_name)
 {
 	fprintf(
 		stderr,
-		"Usage: %s [-bCcdehlnosuv] <trace.dat> [<lttng-trace>] <outdir>\n"
+		"Usage: %s [-bCcdehlnopPsv] <trace.dat> [<lttng-trace>] <outdir>\n"
 		"\n"
 		"Options:\n"
-		"  -b, --begin <ts>      skip until (babeltrace2-filter.utils.trimmer begin input)\n"
-		"  -C, --callstack       Include callstacks in the output\n"
-		"  -c, --ctf-version <v> CTF version to use (default: 1.8)\n"
-		"  -d, --trace-dt <name> ISO‑8601 timestamp of the trace\n"
-		"  -e, --end <ts>        trim after (babeltrace2-filter.utils.trimmer end input)\n"
-		"  -l, --lttng           Convert well-known events to LTTng representation (default: off)\n"
+		"  -b, --begin <ts>        skip until (babeltrace2-filter.utils.trimmer begin input)\n"
+		"  -C, --callstack         Include callstacks in the output\n"
+		"  -c, --ctf-version <v>   CTF version to use (default: 1.8)\n"
+		"  -d, --trace-dt <name>   ISO-8601 timestamp of the trace\n"
+		"  -e, --end <ts>          trim after (babeltrace2-filter.utils.trimmer end input)\n"
+		"  -l, --lttng             Convert well-known events to LTTng representation (default: off)\n"
 		"  -n, --trace-name <name> Name of the trace (session)\n"
 		"  -o, --clock-offset <offset> Trace clock offset in ns to world clock\n"
-		"  -s, --symbolize       Symbolize function addresses\n"
+		"  -p, --progress-fd <fd>  Write progress to file descriptor\n"
+		"  -P, --progress-path <path> Write progress to fifo at path\n"
+		"  -s, --symbolize         Symbolize function addresses\n"
 		"  -u, --clock-uid <(u)uid> Trace clock uuid or uid, depending on MIP version\n"
-		"  -v, --verbose         Increase logging level (repeatable)\n"
-		"  -h, --help            Show this help message and exit\n",
+		"  -v, --verbose           Increase logging level (repeatable)\n"
+		"  -h, --help              Show this help message and exit\n",
 		basename(prog_name));
 }
 
@@ -95,6 +99,7 @@ static void clear_opts(prog_opts *opts)
 	free(opts->trace_datetime);
 	free(opts->trace_name);
 	free(opts->trace_path);
+	free(opts->progress_path);
 	free(opts->lttng_path);
 	free(opts->out_dir);
 	memset(opts, 0, sizeof(*opts));
@@ -106,6 +111,7 @@ int parse_args(int argc, char *argv[], prog_opts *opts)
 	memset(opts, 0, sizeof(*opts));
 	opts->ctf_version = strdup("1.8");
 	opts->loglevel = BT_LOGGING_LEVEL_WARNING;
+	opts->progress_fd = -1;
 
 	// clang-format off
 	static const struct option long_opts[] = {
@@ -120,15 +126,17 @@ int parse_args(int argc, char *argv[], prog_opts *opts)
 		{ "trace-dt",    required_argument, 0, 'd' },
 		{ "trace-name",  required_argument, 0, 'n' },
 		{ "verbose",     no_argument,       0, 'v' },
-		{ "help",        no_argument,       0, 'h' },
-		{ 0,             0,                 0,  0  }
+		{ "help",           no_argument,       0, 'h' },
+		{ "progress-fd",    required_argument, 0, 'p' },
+		{ "progress-path",  required_argument, 0, 'P' },
+		{ 0,                0,                 0,  0  }
 	};
 	// clang-format on
 
 	int opt;
 	int opt_index = 0;
 
-	while ((opt = getopt_long(argc, argv, "b:Cc:d:e:ln:o:u:svh", long_opts,
+	while ((opt = getopt_long(argc, argv, "b:Cc:d:e:ln:o:p:P:svh", long_opts,
 							  &opt_index)) != -1) {
 		switch (opt) {
 		case 'b':
@@ -166,6 +174,13 @@ int parse_args(int argc, char *argv[], prog_opts *opts)
 			break;
 		case 's':
 			opts->symbolize = true;
+			break;
+		case 'p':
+			opts->progress_fd = atoi(optarg);
+			break;
+		case 'P':
+			free(opts->progress_path);
+			opts->progress_path = strdup(optarg);
 			break;
 		case 'v':
 			opts->loglevel = opts->loglevel > 0 ? opts->loglevel - 1 : 0;
@@ -580,6 +595,14 @@ int main(int argc, char **argv)
 	if (opts.trace_datetime) {
 		bt_value_map_insert_string_entry(
 			source_params, "trace-creation-datetime", opts.trace_datetime);
+	}
+	if (opts.progress_fd >= 0) {
+		bt_value_map_insert_signed_integer_entry(source_params, "progress-fd",
+												 opts.progress_fd);
+	}
+	if (opts.progress_path) {
+		bt_value_map_insert_string_entry(source_params, "progress-path",
+										 opts.progress_path);
 	}
 	bt_graph_add_source_component(graph, source_cls, "ftrace", source_params,
 								  opts.loglevel, &source);


### PR DESCRIPTION
Converting the traces can take some time. To give the caller feedback, we add support for psplash progress reporting.