### PR TITLE
feat(tool): process all provided LTTng traces

### DIFF
--- a/man/ftrace-to-ctf.1.in
+++ b/man/ftrace-to-ctf.1.in
@@ -9,6 +9,23 @@ ftrace-to-ctf \- Convert ftrace trace data (trace.dat) to CTF format
 \fBftrace-to-ctf\fR constructs and executes a Babeltrace2 graph that reads ftrace data (produced by \fBtrace-cmd\fR in a \fItrace.dat\fR file) and writes it to a CTF (Common Trace Format) directory.  The program can optionally merge a LTTng trace, trim the trace by timestamps, and set various metadata such as clock offset, clock UID, trace name and creation datetime.
 .PP
 The tool supports both CTF version 1.8 (default) and CTF version 2, automatically selecting the appropriate MIP version for the Babeltrace2 sink.
+.SS LTTng trace discovery
+When a \fIlttng-trace\fR path is given, \fBftrace-to-ctf\fR recursively walks
+that directory and all of its subdirectories to locate the CTF trace
+directories it contains.  For each directory it queries the \fBsource.ctf.fs\fR
+component class (via the \fBbabeltrace.support-info\fR query object) to decide
+whether that directory is a CTF trace directory.  Directories that are
+recognized are used as inputs and are not descended into any further;
+directories that are not recognized are skipped and their children are
+inspected instead.  Symbolic links are not followed.
+.PP
+Discovered trace directories that report the same support-info group are
+combined into a single \fBsource.ctf.fs\fR component, while directories
+belonging to different traces are handled by separate source components.  This
+allows, for example, per-PID LTTng userspace traces to be converted in a single
+run.  The first discovered trace is additionally used to extract the clock
+metadata.  When \fB--verbose\fR is given, the discovery decisions (which
+directories are used or skipped) are logged.
 .SH OPTIONS
 .TP
 \fB-b, --begin \fIts\fR

--- a/meson.build
+++ b/meson.build
@@ -97,7 +97,11 @@ bt2_ftrace_plugin = shared_library('babeltrace-plugin-ftrace',
 )
 
 executable('ftrace-to-ctf',
-  sources: files('src/ftrace-to-ctf.c'),
+  sources: files(
+    'src/ftrace-to-ctf-discovery.c',
+    'src/ftrace-to-ctf-discovery.h',
+    'src/ftrace-to-ctf.c',
+  ),
   install: true,
   dependencies: [tracecmd_dep, traceevent_dep, babeltrace2_dep, json_glib_dep, uuid_dep],
   link_with: bt2_ftrace_plugin

--- a/src/ftrace-to-ctf-discovery.c
+++ b/src/ftrace-to-ctf-discovery.c
@@ -1,0 +1,144 @@
+/*
+ * SPDX-FileCopyrightText: (C) 2026 Siemens
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <babeltrace2/babeltrace.h>
+#include <dirent.h>
+#include <limits.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+
+#include "ftrace-to-ctf-discovery.h"
+
+/* Append path and take ownership of group (which may be NULL). */
+static void lttng_trace_list_append(lttng_trace_list *list, const char *path,
+									char *group)
+{
+	if (list->count == list->cap) {
+		size_t new_cap = list->cap ? list->cap * 2 : 8;
+		lttng_trace_input *tmp = realloc(list->items, new_cap * sizeof(*tmp));
+		if (!tmp) {
+			free(group);
+			return;
+		}
+		list->items = tmp;
+		list->cap = new_cap;
+	}
+	list->items[list->count].path = strdup(path);
+	list->items[list->count].group = group;
+	list->count++;
+}
+
+void lttng_trace_list_clear(lttng_trace_list *list)
+{
+	for (size_t i = 0; i < list->count; ++i) {
+		free(list->items[i].path);
+		free(list->items[i].group);
+	}
+	free(list->items);
+	list->items = NULL;
+	list->count = 0;
+	list->cap = 0;
+}
+
+/*
+ * Query the given source component class whether it can handle 'path' as a
+ * trace directory using the babeltrace.support-info query object. When 'group_out'
+ * is non-NULL, it receives a newly-allocated copy of the reported group name
+ * (or NULL if the input has no group); the caller owns that string.
+ */
+static double query_directory_support(const bt_component_class_source *cls,
+									  const char *path, int loglevel,
+									  char **group_out)
+{
+	if (group_out)
+		*group_out = NULL;
+
+	bt_value *params = bt_value_map_create();
+	if (!params)
+		return 0.0;
+	bt_value_map_insert_string_entry(params, "type", "directory");
+	bt_value_map_insert_string_entry(params, "input", path);
+
+	bt_query_executor *qe = bt_query_executor_create(
+		bt_component_class_source_as_component_class_const(cls),
+		"babeltrace.support-info", params);
+	bt_value_put_ref(params);
+	if (!qe)
+		return 0.0;
+	bt_query_executor_set_logging_level(qe, loglevel);
+
+	const bt_value *result = NULL;
+	double weight = 0.0;
+	if (bt_query_executor_query(qe, &result) ==
+			BT_QUERY_EXECUTOR_QUERY_STATUS_OK &&
+		result) {
+		if (bt_value_is_real(result)) {
+			weight = bt_value_real_get(result);
+		} else if (bt_value_is_map(result)) {
+			const bt_value *w =
+				bt_value_map_borrow_entry_value_const(result, "weight");
+			if (w && bt_value_is_real(w))
+				weight = bt_value_real_get(w);
+			if (group_out) {
+				const bt_value *g =
+					bt_value_map_borrow_entry_value_const(result, "group");
+				if (g && bt_value_is_string(g))
+					*group_out = strdup(bt_value_string_get(g));
+			}
+		}
+		bt_value_put_ref(result);
+	}
+	bt_query_executor_put_ref(qe);
+	return weight;
+}
+
+void discover_lttng_inputs(const bt_component_class_source *cls,
+						   const char *path, lttng_trace_list *list,
+						   int loglevel, bool verbose)
+{
+	char *group = NULL;
+	if (verbose) {
+		fprintf(stderr, "[ftrace-to-ctf][lttng discovery]: checking \"%s\"\n",
+				path);
+	}
+	double weight = query_directory_support(cls, path, loglevel, &group);
+	if (weight > 0.5) {
+		if (verbose) {
+			fprintf(
+				stderr,
+				"[ftrace-to-ctf][lttng discovery]: awarded \"%s\" (weight %.2f%s%s)\n",
+				path, weight, group ? ", group " : "", group ? group : "");
+		}
+		/* list takes ownership of 'group' */
+		lttng_trace_list_append(list, path, group);
+		return;
+	}
+	free(group);
+
+	DIR *dir = opendir(path);
+	if (!dir)
+		return;
+
+	struct dirent *entry;
+	while ((entry = readdir(dir)) != NULL) {
+		if (strcmp(entry->d_name, ".") == 0 || strcmp(entry->d_name, "..") == 0)
+			continue;
+
+		char child[PATH_MAX];
+		int n = snprintf(child, sizeof(child), "%s/%s", path, entry->d_name);
+		if (n < 0 || (size_t)n >= sizeof(child))
+			continue;
+
+		struct stat st;
+		/* use lstat so that symlinks are not followed */
+		if (lstat(child, &st) != 0 || !S_ISDIR(st.st_mode))
+			continue;
+
+		discover_lttng_inputs(cls, child, list, loglevel, verbose);
+	}
+	closedir(dir);
+}

--- a/src/ftrace-to-ctf-discovery.h
+++ b/src/ftrace-to-ctf-discovery.h
@@ -1,0 +1,47 @@
+/**
+ * SPDX-FileCopyrightText: (C) 2026 Siemens
+ * SPDX-License-Identifier: MIT
+ *
+ * Discovery of CTF trace directories below a given path using the
+ * babeltrace.support-info query object. This resembles the autodisc
+ * logic from babeltrace2, which is not available in the C API.
+ */
+
+#ifndef _BT_FTRACE_DISCOVERY_H
+#define _BT_FTRACE_DISCOVERY_H
+
+#include <babeltrace2/babeltrace.h>
+#include <stdbool.h>
+#include <stddef.h>
+
+/*
+ * A discovered CTF trace directory together with the support-info "group" it
+ * belongs to. Directories sharing a non-NULL group form a single logical trace
+ * and must be given to one source component; a NULL group is unique.
+ */
+typedef struct {
+	char *path;
+	char *group;
+} lttng_trace_input;
+
+typedef struct {
+	lttng_trace_input *items;
+	size_t count;
+	size_t cap;
+} lttng_trace_list;
+
+/*
+ * Recursively walk 'path' and its transitive subdirectories. Every directory
+ * that the source component class reports it can handle (support weight > 0) is
+ * appended to 'list' together with its group; the walk does not descend into a
+ * handled directory. Directories that cannot be handled are skipped and their
+ * children are inspected instead. Decisions are logged when 'verbose' is set.
+ */
+void discover_lttng_inputs(const bt_component_class_source *cls,
+						   const char *path, lttng_trace_list *list,
+						   int loglevel, bool verbose);
+
+/* Free all entries of 'list' and reset it to empty. */
+void lttng_trace_list_clear(lttng_trace_list *list);
+
+#endif

--- a/src/ftrace-to-ctf.c
+++ b/src/ftrace-to-ctf.c
@@ -16,6 +16,8 @@
 #include <stdlib.h>
 #include <uuid.h>
 
+#include "ftrace-to-ctf-discovery.h"
+
 /* Structure that holds the parsed options */
 typedef struct {
 	char *begin;
@@ -333,6 +335,7 @@ static int parse_trace_meta(const char *buffer, trace_metadata *trace_meta)
 static int get_metadata_from_lttng_trace(const bt_plugin *ftrace_plugin,
 										 const bt_plugin *ctf_plugin,
 										 const bt_plugin *utils_plugin,
+										 const char *lttng_trace_path,
 										 prog_opts *opts)
 {
 	const bt_component_source *source;
@@ -367,7 +370,7 @@ static int get_metadata_from_lttng_trace(const bt_plugin *ftrace_plugin,
 	bt_value *inputs;
 	bt_value *comp_params = bt_value_map_create();
 	bt_value_map_insert_empty_array_entry(comp_params, "inputs", &inputs);
-	bt_value_array_append_string_element(inputs, opts->lttng_path);
+	bt_value_array_append_string_element(inputs, lttng_trace_path);
 	bt_graph_add_source_component(graph, source_cls, "lttng", comp_params,
 								  opts->loglevel, &source);
 	bt_value_put_ref(comp_params);
@@ -449,7 +452,9 @@ static int get_metadata_from_lttng_trace(const bt_plugin *ftrace_plugin,
 int main(int argc, char **argv)
 {
 	const bt_component_source *source = NULL;
-	const bt_component_source *source_lttng = NULL;
+	const bt_component_source **lttng_sources = NULL;
+	size_t nb_lttng_sources = 0;
+	lttng_trace_list lttng_traces = { 0 };
 	const bt_component_filter *filter = NULL;
 	const bt_component_filter *trimmer = NULL;
 	const bt_component_sink *sink = NULL;
@@ -465,7 +470,7 @@ int main(int argc, char **argv)
 	printf("  lttng :       %s\n", opts.lttng ? "yes" : "no");
 	printf("  ctf-version : %s\n", opts.ctf_version);
 	printf("  trace   :     %s\n", opts.trace_path);
-	printf("  lttng-trace:  %s\n",
+	printf("  lttng-traces: %s\n",
 		   opts.lttng_path ? opts.lttng_path : "not provided");
 	printf("  outdir  :     %s\n", opts.out_dir);
 	if (opts.begin || opts.end) {
@@ -495,8 +500,30 @@ int main(int argc, char **argv)
 	}
 
 	if (opts.lttng_path) {
-		get_metadata_from_lttng_trace(ftrace_plugin, ctf_plugin, utils_plugin,
-									  &opts);
+		bool verbose = opts.loglevel <= BT_LOGGING_LEVEL_INFO;
+		const bt_component_class_source *ctf_fs_cls =
+			bt_plugin_borrow_source_component_class_by_name_const(ctf_plugin,
+																  "fs");
+		/*
+		 * Walk all transitive directories below opts.lttng_path once and ask
+		 * the ctf.fs source component class (via babeltrace.support-info) which
+		 * of them are CTF trace directories. This resembles the autodisc logic
+		 * from babeltrace2.
+		 */
+		if (ctf_fs_cls) {
+			discover_lttng_inputs(ctf_fs_cls, opts.lttng_path, &lttng_traces,
+								  opts.loglevel, verbose);
+		}
+		if (lttng_traces.count > 0) {
+			get_metadata_from_lttng_trace(ftrace_plugin, ctf_plugin,
+										  utils_plugin,
+										  lttng_traces.items[0].path, &opts);
+		} else {
+			fprintf(stderr,
+					"Warning: no CTF trace found under \"%s\"; "
+					"cannot extract clock metadata.\n",
+					opts.lttng_path);
+		}
 	}
 	printf("  clock-offset: %lu\n", opts.clock_offset);
 	printf("  clock-uid:    %s\n",
@@ -586,14 +613,51 @@ int main(int argc, char **argv)
 	bt_value_put_ref(source_params);
 
 	/* optional lttng trace input */
-	if (opts.lttng_path) {
-		source_params = bt_value_map_create();
-		bt_value_map_insert_empty_array_entry(source_params, "inputs", &inputs);
-		bt_value_array_append_string_element(inputs, opts.lttng_path);
-		bt_graph_add_source_component(graph, source_lttng_cls, "lttng",
-									  source_params, opts.loglevel,
-									  &source_lttng);
-		bt_value_put_ref(source_params);
+	if (lttng_traces.count > 0) {
+		/*
+		 * Directories that report the same support-info group form a single
+		 * logical trace and must be given to one source component; directories
+		 * with different identities need separate components, otherwise ctf.fs
+		 * rejects them ("identities don't match").
+		 */
+		lttng_sources = calloc(lttng_traces.count, sizeof(*lttng_sources));
+		bool *consumed = calloc(lttng_traces.count, sizeof(*consumed));
+		for (size_t i = 0; i < lttng_traces.count; ++i) {
+			if (consumed[i])
+				continue;
+			consumed[i] = true;
+
+			source_params = bt_value_map_create();
+			bt_value_map_insert_empty_array_entry(source_params, "inputs",
+												  &inputs);
+			bt_value_array_append_string_element(inputs,
+												 lttng_traces.items[i].path);
+
+			/* gather all further directories with the same group */
+			if (lttng_traces.items[i].group) {
+				for (size_t j = i + 1; j < lttng_traces.count; ++j) {
+					if (!consumed[j] && lttng_traces.items[j].group &&
+						strcmp(lttng_traces.items[i].group,
+							   lttng_traces.items[j].group) == 0) {
+						bt_value_array_append_string_element(
+							inputs, lttng_traces.items[j].path);
+						consumed[j] = true;
+					}
+				}
+			}
+
+			char comp_name[32];
+			snprintf(comp_name, sizeof(comp_name), "lttng%zu",
+					 nb_lttng_sources);
+			const bt_component_source *src = NULL;
+			bt_graph_add_source_component(graph, source_lttng_cls, comp_name,
+										  source_params, opts.loglevel, &src);
+			bt_value_put_ref(source_params);
+			if (src)
+				lttng_sources[nb_lttng_sources++] = src;
+		}
+		free(consumed);
+		lttng_trace_list_clear(&lttng_traces);
 	}
 
 	bt_graph_add_filter_component(graph, filter_cls, "muxer", NULL,
@@ -649,27 +713,30 @@ int main(int argc, char **argv)
 
 	const uint64_t nb_ft_ports =
 		bt_component_source_get_output_port_count(source);
+	uint64_t muxer_in_idx = 0;
 	for (uint64_t i = 0; i < nb_ft_ports; ++i) {
 		const bt_port_output *ft_out =
 			bt_component_source_borrow_output_port_by_index_const(source, i);
 		const bt_port_input *f_in =
-			bt_component_filter_borrow_input_port_by_index_const(filter, i);
+			bt_component_filter_borrow_input_port_by_index_const(
+				filter, muxer_in_idx++);
 		bt_graph_connect_ports(graph, ft_out, f_in, NULL);
 	}
-	/* plumbing of optional lttng source */
-	if (opts.lttng_path) {
+	/* plumbing of optional lttng sources */
+	for (size_t s = 0; s < nb_lttng_sources; ++s) {
 		const uint64_t nb_lttng_ports =
-			bt_component_source_get_output_port_count(source_lttng);
+			bt_component_source_get_output_port_count(lttng_sources[s]);
 		for (uint64_t i = 0; i < nb_lttng_ports; ++i) {
 			const bt_port_output *lttng_out =
 				bt_component_source_borrow_output_port_by_index_const(
-					source_lttng, i);
+					lttng_sources[s], i);
 			const bt_port_input *f_in =
 				bt_component_filter_borrow_input_port_by_index_const(
-					filter, i + nb_ft_ports);
+					filter, muxer_in_idx++);
 			bt_graph_connect_ports(graph, lttng_out, f_in, NULL);
 		}
 	}
+	free(lttng_sources);
 
 	const bt_port_output *f_out =
 		bt_component_filter_borrow_output_port_by_index_const(filter, 0);


### PR DESCRIPTION
Previously only a single lttng trace could be processed. However, on real use-cases we have multiple trace providers, usually creating one trace per pid. To process all traces, we implement a discovery logic similar to the builtin one of babeltrace2 in autodisc.c (which unfortunately is not exposed as API). With that, we traverse the provided dir and check if the CTF source is able to handle it. If so, the dir is awarded to later be processed.

As a single CTF source is only able to process traces from the same tracing instance, we have to group them. All traces of a single group are provided as multiple inputs to a CTF source. Each group hereby uses its own CTF source.